### PR TITLE
Change vcds version from 21.9.0 to 25.3.2

### DIFF
--- a/scripts/stable-branch/vcds-install.sh
+++ b/scripts/stable-branch/vcds-install.sh
@@ -392,7 +392,7 @@ function winetricks-standard {
    WINEPREFIX=/home/$USER/.wineprefixes/vcds sh winetricks -q corefonts win8 &&
    mkdir -p vcdsdownload &&
    cd vcdsdownload &&
-   wget https://dltemp.ross-tech.com/VCDS/download/O8934p/VCDS-Release-21.9.0-Installer.exe -O VCDS.exe &&
+   wget https://dltemp.ross-tech.com/VCDS/download/T73E79/VCDS-Release-25.3.2-Installer.exe -O VCDS.exe &&
    WINEPREFIX=/home/$USER/.wineprefixes/vcds wine VCDS.exe &&
    logfile-installation-standard &&
    program-exit


### PR DESCRIPTION
Changed the version of the vcds download in winetricks-standard function, since the old version download link was returning a 404.